### PR TITLE
split ticker into two separate templates

### DIFF
--- a/breaking-headline.html
+++ b/breaking-headline.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>breaking-headline</title>
+  <script src="js/jquery-3.3.1.min.js"></script>
+  <script src="js/webcg-framework.umd.js"></script>
+  <script type="text/javascript" src="js/headline.js"></script>
+  <link rel="stylesheet" type="text/css" href="css/colors-breaking.css">
+  <link rel="stylesheet" type="text/css" href="css/basics.css">
+  <link rel="stylesheet" type="text/css" href="css/headline.css">
+</head>
+<body>
+  <div class="main headline" id="main">
+    <div class="f0_bg" id="f0_bg">
+      <div class="f0_text" id="f0_text"></div>
+    </div>
+    <div class="f1_bg" id="f1_bg">
+      <div class="f1_text" id="f1_text"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/breaking-ticker.html
+++ b/breaking-ticker.html
@@ -1,56 +1,48 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>standard-ticker</title>
-		<script>
-			// This CasparCG template is made for Svenska YLE by Niclas Hallgren 2018
-			// The WebTicker script used is commercially licensed to Niclas Hallgren and may not be used in other templates without proper license
-			// https://maze.digital/webticker/license/
-			
-			// f0 = flockler id
-			// f1 = line 1
-			// f2 = line 2
-			// f3 = line 3 left
-			// f4 = "", manual ticker data, f0 must be empty or 0 for this to be used
-			// f5 = 10, how many articles to show (max 20)
-			// f6 = false, [true,false] show only text inside <strong></strong> tags
-			
-			start = new Date().getTime();
-		</script>
-    <link rel="stylesheet" type="text/css" href="css/colors-breaking.css">
-    <link rel="stylesheet" type="text/css" href="css/basics.css">
-		<link rel="stylesheet" type="text/css" href="css/ticker.css">
-    <script src="js/webcg-framework.umd.js"></script>
-		<script src="js/jquery-3.3.1.min.js"></script>
-		<script src="js/jquery.webticker.min.js"></script>
-		<script src="js/ticker.js"></script>
-		<script src="js/flockler.js"></script>
-    </head>
-    <body>
-		<div class="main" id="main">
-			<div class="f1_bg" id="f1_bg">
-				<div class="f1_text" id="f1_text"></div>
-			</div>
-			<div class="f2_bg" id="f2_bg">
-				<div class="f2_text" id="f2_text"></div>
-			</div>
-			<div class="f3_bg" id="f3_bg">
-				<div class="f3_text" id="f3_text"></div>
-			</div>
-			<div class="ticker_bg" id="ticker_bg">
-				<div class="ticker" id="ticker">
-					<ul class="webTicker" id="webTicker">
-						<li>&nbsp;</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-    </body>
-	<script>
-		$(document).ready(function() {
-			ready = new Date().getTime();
-			console.log('Flockler Template Load Time: ' + (ready-start) + 'ms');
-		});
-	</script>
+<head>
+  <meta charset="utf-8">
+  <title>breaking-ticker</title>
+  <script>
+    // This CasparCG template is made for Svenska YLE by Niclas Hallgren 2018
+    // The WebTicker script used is commercially licensed to Niclas Hallgren and may not be used in other templates without proper license
+    // https://maze.digital/webticker/license/
+    
+    // f0 = flockler id
+    // f1 = line 1 left
+    // f2 = "", manual ticker data, f0 must be empty or 0 for this to be used
+    // f3 = 10, how many articles to show (max 20)
+    // f4 = false, [true,false] show only text inside <strong></strong> tags
+    
+    start = new Date().getTime();
+  </script>
+  <link rel="stylesheet" type="text/css" href="css/colors-breaking.css">
+  <link rel="stylesheet" type="text/css" href="css/basics.css">
+  <link rel="stylesheet" type="text/css" href="css/ticker.css">
+  <script src="js/webcg-framework.umd.js"></script>
+  <script src="js/jquery-3.3.1.min.js"></script>
+  <script src="js/jquery.webticker.min.js"></script>
+  <script src="js/ticker.js"></script>
+  <script src="js/flockler.js"></script>
+</head>
+<body>
+  <div class="main" id="main">
+    <div class="f1_bg" id="f1_bg">
+      <div class="f1_text" id="f1_text"></div>
+    </div>
+    <div class="ticker_bg" id="ticker_bg">
+      <div class="ticker" id="ticker">
+        <ul class="webTicker" id="webTicker">
+          <li>&nbsp;</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</body>
+<script>
+  $(document).ready(function() {
+    ready = new Date().getTime();
+    console.log('Flockler Template Load Time: ' + (ready-start) + 'ms');
+  });
+</script>
 </html>

--- a/css/headline.css
+++ b/css/headline.css
@@ -1,0 +1,45 @@
+:root {
+  /* Define a variable for the margin of the overlay, ~70px at 1080p */
+  --margin: 3.65vmax;
+}
+
+.main {
+  position: absolute;
+  top: calc(12 * var(--margin));
+  left: var(--margin);
+  width: calc(100vw - 2 * var(--margin) - 12vw);
+  opacity: 0;
+}
+
+.f0_bg {
+  background: var(--main-color);
+  display: table;
+  position: relative;
+  padding: 0.2em 0.4em;
+}
+
+.f0_text {
+  color: var(--white-color);
+  font-family: 'Yle-Black';
+  font-size: 0.8rem;
+  line-height: 1;
+  width: 100%;
+}
+
+.f1_bg {
+  background: var(--white-color);
+  display: table;
+  position: relative;
+  padding: 0.1em 0.4em 0em;
+  width: 100%;
+}
+
+.f1_text {
+  color: var(--black-color);
+  font-family: 'Yle-Black';
+  font-size: 1.45rem;
+  line-height: 1.25;
+  overflow: hidden;
+  white-space: nowrap;
+  letter-spacing: -0.05rem;
+}

--- a/css/ticker.css
+++ b/css/ticker.css
@@ -5,46 +5,13 @@
 
 .main {
   position: absolute;
-  top: calc(12 * var(--margin));
+  top: calc(12 * var(--margin) + 3.05em);
   left: var(--margin);
   width: calc(100vw - 2 * var(--margin) - 12vw);
   opacity: 0;
 }
 
 .f1_bg {
-  background: var(--main-color);
-  display: table;
-  position: relative;
-  padding: 0.2em 0.4em;
-}
-
-.f1_text {
-  color: var(--white-color);
-  font-family: 'Yle-Black';
-  font-size: 0.8rem;
-  line-height: 1;
-  width: 100%;
-}
-
-.f2_bg {
-  background: var(--white-color);
-  display: table;
-  position: relative;
-  padding: 0.1em 0.4em 0em;
-  width: 100%;
-}
-
-.f2_text {
-  color: var(--black-color);
-  font-family: 'Yle-Black';
-  font-size: 1.45rem;
-  line-height: 1.25;
-  overflow: hidden;
-  white-space: nowrap;
-  letter-spacing: -0.05rem;
-}
-
-.f3_bg {
   z-index: 2;
   background: #252525;
   float: left;
@@ -52,7 +19,7 @@
   padding: 0.1em 0.4em;
 }
 
-.f3_text {
+.f1_text {
   color: var(--white-color);
   font-family: 'Yle-Regular';
   font-size: 0.9rem;

--- a/js/flockler.js
+++ b/js/flockler.js
@@ -2,9 +2,9 @@
 
 var data = "";
 var flocklerId = flocklerIdLast = 0;
-var f1Last = f2Last = f3Last = f4 = "";
-var f5 = 10;
-var f6 = false;
+var f1Last = f2 = "";
+var f3 = 10;
+var f4 = false;
 var articles = tmpArticles = lastArticles = [];
 var intervalRun = false;
 var intervalId;
@@ -71,8 +71,8 @@ function sanitizeFlocklerData(str) {
     //if (pos != -1 && pos < 30) {
         str = str.substring(pos);
     //}
-    if (f6) {
-		// If f6 is set to true, only output text between <strong></strong> tags
+    if (f4) {
+		// If f4 is set to true, only output text between <strong></strong> tags
 		var count = (str.match(/<strong>/g) || []).length;
         if (count == 0) {
             return null;
@@ -114,8 +114,8 @@ function convertUserTicker(str) {
     for (i = 0; i < userData.length; i++) {
         tmpArticles.push('<li>' + sanitizeData(userData[i]) + '&nbsp;&nbsp;&vert;&nbsp;</li>');
     }
-    // How many articles to show (defaults to 10 if no value set in client (f5))
-    articles = tmpArticles.slice(0, f5);
+    // How many articles to show (defaults to 10 if no value set in client (f3))
+    articles = tmpArticles.slice(0, f3);
     // If fetched articles not equal to last fetch, update ticker
     if (!articlesEqual(articles, lastArticles)) { 
         fadeOutTicker(articles);
@@ -142,8 +142,8 @@ function fetchFlockler() {
             });
             // Reverse order, oldest article first
             //tmpArticles = tmpArticles.reverse();
-            // How many articles to show (defaults to 10 if no value set in client (f5))
-            articles = tmpArticles.slice(0, f5);
+            // How many articles to show (defaults to 10 if no value set in client (f3))
+            articles = tmpArticles.slice(0, f3);
             // If fetched articles not equal to last fetch update ticker
             if (!articlesEqual(articles, lastArticles)) { 
                 fadeOutTicker(articles);

--- a/js/headline.js
+++ b/js/headline.js
@@ -1,0 +1,94 @@
+// This CasparCG template is made for Svenska YLE by Niclas Hallgren 2018
+
+// Template opacity
+var maxOpacity = 1;
+
+function play() {
+  // Wait 40ms to load fonts before executing play command
+  function delayed(){
+    $( "#main" ).fadeTo(500, maxOpacity);
+  }
+  setTimeout(delayed, 400);
+}
+
+function stop() {
+  // Fade out everything on stop
+  $( "#main" ).fadeTo(500, 0);
+}
+
+function next() {
+  // The next function has no functionality in this template
+}
+
+function update(str) {
+  // This function is executed every time the template is played or updated
+  var data = "";
+  // Check if user input is empty
+  if (str != "" || str != "<templateData></templateData>") {
+    try {
+      // Input JSON, parse to data variable
+      data = JSON.parse(str);
+    } catch (e) {
+      data = "";
+      // Input not JSON
+    }
+  }
+  // If data not JSON, do nothing
+  if (data!="") {
+    // Check if f0 is set by user
+    if (data.f0 != "" && typeof data.f0 != 'undefined') {
+      var f0 = document.getElementById('f0_text');
+      // Check if f1 is visible
+      if (f0.innerHTML == "") {
+        // Set input and fade in
+        $(" .f0_bg ").css({"visibility": "visible"});
+        f0.innerHTML = f0Last = data.f0.trim();
+        $( "#f0_bg" ).fadeTo( 250, maxOpacity );
+      } else {
+        // If f1 visible, fade out, replace and fade in
+        if (data.f0 != f0Last){
+          $( "#f0_bg" ).fadeTo( 250 , 0, function() {
+            $(" .f0_bg ").css({"visibility": "visible"});
+            f0Last = f0.innerHTML = data.f0.trim();
+          });
+          $( "#f0_bg" ).fadeTo( 250 , maxOpacity );
+        } 
+      }
+    } else {
+      // If f1 is not set fade out and clear
+      $( "#f0_bg" ).fadeTo( 250 , 0, function() {
+        $( ".f0_bg" ).css({"visibility": "hidden"});
+        f0Last = "";
+      });
+    }
+
+    if (data.f1 != "" && typeof data.f1 != 'undefined') {
+      var f1 = document.getElementById('f1_text');
+      if (f1.innerHTML == "") {
+        $(" .f1_bg ").css({"visibility": "visible"});
+        f1.innerHTML = f1Last = data.f1.trim();
+        $( "#f1_bg" ).fadeTo( 250, maxOpacity );
+      } else {
+        if (data.f1 != f1Last){
+          $( "#f1_bg" ).fadeTo( 250 , 0, function() {
+            $(" .f1_bg ").css({"visibility": "visible"});
+            f1Last = f1.innerHTML = data.f1.trim();
+          });
+          $( "#f1_bg" ).fadeTo( 250 , maxOpacity );
+        } 
+      }
+    } else {
+      $( "#f1_bg" ).fadeTo( 250 , 0, function() {
+        $( ".f1_bg" ).css({"visibility": "hidden"});
+        f1Last = "";
+      });
+    }
+  } else {
+    // Template input not JSON or not set at all, do not show anything
+    $( ".f0_bg" ).css({"visibility": "hidden"});
+    $( ".f1_bg" ).css({"visibility": "hidden"});
+    // Output error to CasparCG log (if set to log by CasparCG settings)
+    console.log("Warning! Input data not JSON!")
+  }
+
+}

--- a/js/ticker.js
+++ b/js/ticker.js
@@ -4,192 +4,141 @@
 var maxOpacity = 1;
 
 function play() {
-	// Wait 40ms to load fonts before executing play command
-	function delayed(){
-			autoFetchFlockler();
-			$( "#main" ).fadeTo( 500 , maxOpacity );
-	}
-	setTimeout(delayed, 400);
+  // Wait 40ms to load fonts before executing play command
+  function delayed(){
+    autoFetchFlockler();
+    $( "#main" ).fadeTo(500, maxOpacity);
+  }
+  setTimeout(delayed, 400);
 }
 
 function stop() {
-	// Fade out everything on stop
-	$( "#main" ).fadeTo( 500 , 0, function() {
-		$("#webTicker").webTicker('stop');
-	});
+  // Fade out everything on stop
+  $( "#main" ).fadeTo(500, 0, function() {
+    $("#webTicker").webTicker('stop');
+  });
 }
 
 function next() {
-	// The next function has no functionality in this template
+  // The next function has no functionality in this template
 }
 
 function update(str) {
-	// This function is executed every time the tempalte is played or updated
-	var data = "";
-	$( ".ticker_bg" ).css({"visibility": "hidden"});
-	// Check if user input is empty
-	if (str != "" || str != "<templateData></templateData>") {
-		try {
-			// Input JSON, parse to data variable
-			data = JSON.parse(str);
-		} catch (e) {
-			data = "";
-			// Input not JSON
-		}
-	}
-	// If data not JSON, do nothing
-	if (data!="") {
-		if ((data.f4 == "" || typeof data.f4 == 'undefined') && (typeof data.f0 == 'undefined' || data.f0 == "" || data.f0 == 0)) {
-			$( ".ticker_bg" ).css({"visibility": "hidden"});
-		} else {
-			$( ".ticker_bg" ).css({"visibility": "visible"});
-		}
-		
-		// Check if f1 is set by user
-		if (data.f1 != "" && typeof data.f1 != 'undefined') {
-			var f1 = document.getElementById('f1_text');
-			// Check if f1 is visible
-			if (f1.innerHTML == "") {
-				// Set input and fade in
-				$(" .f1_bg ").css({"visibility": "visible"});
-				f1.innerHTML = f1Last = data.f1.trim();
-				$( "#f1_bg" ).fadeTo( 250, maxOpacity );
-			} else {
-				// If f1 visible, fade out, replace and fade in
-				if (data.f1 != f1Last){
-					$( "#f1_bg" ).fadeTo( 250 , 0, function() {
-						$(" .f1_bg ").css({"visibility": "visible"});
-						f1Last = f1.innerHTML = data.f1.trim();
-					});
-					$( "#f1_bg" ).fadeTo( 250 , maxOpacity );
-				} 
-			}
-		} else {
-			// If f1 is not set fade out and clear
-			$( "#f1_bg" ).fadeTo( 250 , 0, function() {
-				$( ".f1_bg" ).css({"visibility": "hidden"});
-				f1Last = "";
-			});
-		}
+  // This function is executed every time the tempalte is played or updated
+  var data = "";
+  $( ".ticker_bg" ).css({"visibility": "hidden"});
+  // Check if user input is empty
+  if (str != "" || str != "<templateData></templateData>") {
+    try {
+      // Input JSON, parse to data variable
+      data = JSON.parse(str);
+    } catch (e) {
+      data = "";
+      // Input not JSON
+    }
+  }
+  // If data not JSON, do nothing
+  if (data!="") {
+    if ((data.f2 == "" || typeof data.f2 == 'undefined') && (typeof data.f0 == 'undefined' || data.f0 == "" || data.f0 == 0)) {
+      $( ".ticker_bg" ).css({"visibility": "hidden"});
+    } else {
+      $( ".ticker_bg" ).css({"visibility": "visible"});
+    }
 
-		if (data.f2 != "" && typeof data.f2 != 'undefined') {
-			var f2 = document.getElementById('f2_text');
-			if (f2.innerHTML == "") {
-				$(" .f2_bg ").css({"visibility": "visible"});
-				f2.innerHTML = f2Last = data.f2.trim();
-				$( "#f2_bg" ).fadeTo( 250, maxOpacity );
-			} else {
-				if (data.f2 != f2Last){
-					$( "#f2_bg" ).fadeTo( 250 , 0, function() {
-						$(" .f2_bg ").css({"visibility": "visible"});
-						f2Last = f2.innerHTML = data.f2.trim();
-					});
-					$( "#f2_bg" ).fadeTo( 250 , maxOpacity );
-				} 
-			}
-		} else {
-			$( "#f2_bg" ).fadeTo( 250 , 0, function() {
-				$( ".f2_bg" ).css({"visibility": "hidden"});
-				f1Last = "";
-			});
-		}
+    if (data.f1 != "" && typeof data.f1 != 'undefined') {
+      var f1 = document.getElementById('f1_text');
+      if (f1.innerHTML == "") {
+        $(" .f1_bg ").css({"display": "block"});
+        $( ".f1_bg" ).css({"visibility": "visible"});
+        f1.innerHTML = f1Last = data.f1.trim();
+        $( "#f1_bg" ).fadeTo( 250, maxOpacity );
+      } else {
+        if (data.f1 != f1Last){
+          $( "#f1_bg" ).fadeTo( 250 , 0, function() {
+            f1Last = f1.innerHTML = data.f1.trim();
+          });
+          $( "#f1_bg" ).fadeTo( 250 , maxOpacity );
+        } 
+      }
+    } else {
+      $( "#f1_bg" ).fadeTo( 250 , 0, function() {
+        $(" .f1_bg ").css({"display": "none"});
+      });  
+      f1Last = "";
+    }
 
-		if (data.f3 != "" && typeof data.f3 != 'undefined') {
-			var f3 = document.getElementById('f3_text');
-			if (f3.innerHTML == "") {
-				$(" .f3_bg ").css({"display": "block"});
-				$( ".f3_bg" ).css({"visibility": "visible"});
-				f3.innerHTML = f3Last = data.f3.trim();
-				$( "#f3_bg" ).fadeTo( 250, maxOpacity );
-			} else {
-				if (data.f3 != f3Last){
-					$( "#f3_bg" ).fadeTo( 250 , 0, function() {
-						f3Last = f3.innerHTML = data.f3.trim();
-					});
-					$( "#f3_bg" ).fadeTo( 250 , maxOpacity );
-				} 
-			}
-		} else {
-			$( "#f3_bg" ).fadeTo( 250 , 0, function() {
-				$(" .f3_bg ").css({"display": "none"});
-			});	
-			f3Last = "";
-		}
+    // Check if f3 is set and is a number (how many articles to show)
+    if (typeof data.f3 != 'undefined' && data.f3 != "" && parseInt(data.f3) != 0 && Number.isInteger(parseInt(data.f3.trim()))) {
+      f3 = parseInt(data.f3.trim());
+    } else {
+      // If f3 is not set, use 10 as default
+      f3 = 10;
+    }
 
-		// Check if f5 is set and is a number (how many articles to show)
-		if (typeof data.f5 != 'undefined' && data.f5 != "" && parseInt(data.f5) != 0 && Number.isInteger(parseInt(data.f5.trim()))) {
-			f5 = parseInt(data.f5.trim());
-		} else {
-			// If f5 is not set, use 10 as default
-			f5 = 10;
-		}
+    // Check if f4 is set (if true the template will only show text within <strong></strong> tags)
+    if (typeof data.f4 != 'undefined' && data.f4 != "") {
+      // If true set as true else as false
+      if (data.f4 == "true") {
+        f4 = true;
+      } else if (data.f4 == "false") {
+        f4 = false;
+      }
+    } else {
+      f4 = false;
+    }
 
-		// Check if f6 is set (if true the template will only show text within <strong></strong> tags)
-		if (typeof data.f6 != 'undefined' && data.f6 != "") {
-			// If true set as true else as false
-			if (data.f6 == "true") {
-				f6 = true;
-			} else if (data.f6 == "false") {
-				f6 = false;
-			}
-		} else {
-			f6 = false;
-		}
+    // Check if Flockler id is set, is a number and has not changed since last fetch from server
+    if (typeof data.f0 != 'undefined' && data.f0 != "" && data.f0 != 0 && Number.isInteger(parseInt(data.f0))) {
+      if (flocklerIdLast != data.f0.trim()) {
+        // Check if ticker is running, start if not
+        if (!tickerOn) {
+          startTicker();
+          tickerOn = true;
+        }
+        // Set Flockler id based on user input
+        flocklerId = flocklerIdLast = data.f0.trim();
+        // Start auto fetch from Flockler
+        autoFetchFlockler();
+      }
+    } else {
+      // Flockler id not set, clear old Flockler id and articles
+      flocklerId = flocklerIdLast = 0;
+      articles = [];
+      // Stop auto fetch from Flockler
+      intervalRun = false;
+      clearInterval(intervalId);
+      if (tickerOn) {
+        fadeOutTicker('<li>&nbsp;</li>');
+      }
+    }
 
-		// Check if Flockler id is set, is a number and has not changed since last fetch from server
-		if (typeof data.f0 != 'undefined' && data.f0 != "" && data.f0 != 0 && Number.isInteger(parseInt(data.f0))) {
-			if (flocklerIdLast != data.f0.trim()) {
-				// Check if ticker is running, start if not
-				if (!tickerOn) {
-					startTicker();
-					tickerOn = true;
-				}
-				// Set Flockler id based on user input
-				flocklerId = flocklerIdLast = data.f0.trim();
-				// Start auto fetch from Flockler
-				autoFetchFlockler();
-			}
-		} else {
-			// Flockler id not set, clear old Flockler id and articles
-			flocklerId = flocklerIdLast = 0;
-			articles = [];
-			// Stop auto fetch from Flockler
-			intervalRun = false;
-			clearInterval(intervalId);
-			if (tickerOn) {
-				fadeOutTicker('<li>&nbsp;</li>');
-			}
-		}
+    // Is f2 set (user generated ticker content)
+    if (data.f2 != "" && typeof data.f2 !== 'undefined') {
+      // Is Flockler id 0 or unset
+      if (data.f0 == "" || data.f0 == 0 || typeof data.f0 == 'undefined') {
+        // Start ticker if not running
+        if (!tickerOn) {
+          startTicker();
+          tickerOn = true;
+        }
+        f2 = data.f2.trim();
+        // Convert user input to ticker data
+        convertUserTicker(f2);
+      } else {
+        // Flockler id is set do not use user ticker input
+        f2 = "";
+      }
+    } else {
+      // f2 not set
+      f2 = "";
+    }
 
-		// Is f4 set (user generated ticker content)
-		if (data.f4 != "" && typeof data.f4 !== 'undefined') {
-			// Is Flockler id 0 or unset
-			if (data.f0 == "" || data.f0 == 0 || typeof data.f0 == 'undefined') {
-				// Start ticker if not running
-				if (!tickerOn) {
-					startTicker();
-					tickerOn = true;
-				}
-				f4 = data.f4.trim();
-				// Convert user input to ticker data
-				convertUserTicker(f4);
-			} else {
-				// Flockler id is set do not use user ticker input
-				f4 = "";
-			}
-		} else {
-			// f4 not set
-			f4 = "";
-		}
-
-	} else {
-		// Template input not JSON or not set at all, do not show anything
-		$( ".f1_bg" ).css({"visibility": "hidden"});
-		$( ".f2_bg" ).css({"visibility": "hidden"});
-		$( ".f3_bg" ).css({"visibility": "hidden"});
-		$( ".ticker_bg" ).css({"visibility": "hidden"});
-		// Output error to CasparCG log (if set to log by CasparCG settings)
-		console.log("Warning! Input data not JSON!")
-	}
+  } else {
+    // Template input not JSON or not set at all, do not show anything
+    $( ".f1_bg" ).css({"visibility": "hidden"});
+    $( ".ticker_bg" ).css({"visibility": "hidden"});
+    // Output error to CasparCG log (if set to log by CasparCG settings)
+    console.log("Warning! Input data not JSON!")
+  }
 
 }

--- a/standard-headline.html
+++ b/standard-headline.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>standard-headline</title>
+  <script src="js/jquery-3.3.1.min.js"></script>
+  <script src="js/webcg-framework.umd.js"></script>
+  <script type="text/javascript" src="js/headline.js"></script>
+  <link rel="stylesheet" type="text/css" href="css/colors-standard.css">
+  <link rel="stylesheet" type="text/css" href="css/basics.css">
+  <link rel="stylesheet" type="text/css" href="css/headline.css">
+</head>
+<body>
+  <div class="main headline" id="main">
+    <div class="f0_bg" id="f0_bg">
+      <div class="f0_text" id="f0_text"></div>
+    </div>
+    <div class="f1_bg" id="f1_bg">
+      <div class="f1_text" id="f1_text"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/standard-ticker.html
+++ b/standard-ticker.html
@@ -1,56 +1,48 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>standard-ticker</title>
-		<script>
-			// This CasparCG template is made for Svenska YLE by Niclas Hallgren 2018
-			// The WebTicker script used is commercially licensed to Niclas Hallgren and may not be used in other templates without proper license
-			// https://maze.digital/webticker/license/
-			
-			// f0 = flockler id
-			// f1 = line 1
-			// f2 = line 2
-			// f3 = line 3 left
-			// f4 = "", manual ticker data, f0 must be empty or 0 for this to be used
-			// f5 = 10, how many articles to show (max 20)
-			// f6 = false, [true,false] show only text inside <strong></strong> tags
-			
-			start = new Date().getTime();
-		</script>
-    <link rel="stylesheet" type="text/css" href="css/colors-standard.css">
-    <link rel="stylesheet" type="text/css" href="css/basics.css">
-		<link rel="stylesheet" type="text/css" href="css/ticker.css">
-    <script src="js/webcg-framework.umd.js"></script>
-		<script src="js/jquery-3.3.1.min.js"></script>
-		<script src="js/jquery.webticker.min.js"></script>
-		<script src="js/ticker.js"></script>
-		<script src="js/flockler.js"></script>
-    </head>
-    <body>
-		<div class="main" id="main">
-			<div class="f1_bg" id="f1_bg">
-				<div class="f1_text" id="f1_text"></div>
-			</div>
-			<div class="f2_bg" id="f2_bg">
-				<div class="f2_text" id="f2_text"></div>
-			</div>
-			<div class="f3_bg" id="f3_bg">
-				<div class="f3_text" id="f3_text"></div>
-			</div>
-			<div class="ticker_bg" id="ticker_bg">
-				<div class="ticker" id="ticker">
-					<ul class="webTicker" id="webTicker">
-						<li>&nbsp;</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-    </body>
-	<script>
-		$(document).ready(function() {
-			ready = new Date().getTime();
-			console.log('Flockler Template Load Time: ' + (ready-start) + 'ms');
-		});
-	</script>
+<head>
+  <meta charset="utf-8">
+  <title>standard-ticker</title>
+  <script>
+    // This CasparCG template is made for Svenska YLE by Niclas Hallgren 2018
+    // The WebTicker script used is commercially licensed to Niclas Hallgren and may not be used in other templates without proper license
+    // https://maze.digital/webticker/license/
+    
+    // f0 = flockler id
+    // f1 = line 1 left
+    // f2 = "", manual ticker data, f0 must be empty or 0 for this to be used
+    // f3 = 10, how many articles to show (max 20)
+    // f4 = false, [true,false] show only text inside <strong></strong> tags
+    
+    start = new Date().getTime();
+  </script>
+  <link rel="stylesheet" type="text/css" href="css/colors-standard.css">
+  <link rel="stylesheet" type="text/css" href="css/basics.css">
+  <link rel="stylesheet" type="text/css" href="css/ticker.css">
+  <script src="js/webcg-framework.umd.js"></script>
+  <script src="js/jquery-3.3.1.min.js"></script>
+  <script src="js/jquery.webticker.min.js"></script>
+  <script src="js/ticker.js"></script>
+  <script src="js/flockler.js"></script>
+</head>
+<body>
+  <div class="main" id="main">
+    <div class="f1_bg" id="f1_bg">
+      <div class="f1_text" id="f1_text"></div>
+    </div>
+    <div class="ticker_bg" id="ticker_bg">
+      <div class="ticker" id="ticker">
+        <ul class="webTicker" id="webTicker">
+          <li>&nbsp;</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</body>
+<script>
+  $(document).ready(function() {
+    ready = new Date().getTime();
+    console.log('Flockler Template Load Time: ' + (ready-start) + 'ms');
+  });
+</script>
 </html>


### PR DESCRIPTION
`standard-ticker.html` is now split into `standard-ticker.html` (containing only the Flockler fields) and `standard-headline.html` (containing two text fields). Same with the corresponding breaking templates. The code was also cleaned up a bit.